### PR TITLE
Add charset initialization to admin DB connection

### DIFF
--- a/admin/includes/db.php
+++ b/admin/includes/db.php
@@ -10,6 +10,7 @@ $password = $_ENV['DB_PASS'];
 $database = $_ENV['DB_NAME'];
 
 $conn = new mysqli($host, $username, $password, $database);
+$conn->set_charset('utf8mb4');
 if ($conn->connect_error) {
     die("Connection failed: " . $conn->connect_error);
 }


### PR DESCRIPTION
## Summary
- ensure admin DB connection uses utf8mb4 charset like the main site

## Testing
- `php -l admin/includes/db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b43c65fc8325885d6b8cf23a163f