### PR TITLE
Fix FAQ links

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -9,7 +9,7 @@
           <li><a href="#" class="text-light text-decoration-none">Services</a></li>
           <li><a href="#" class="text-light text-decoration-none">Our Clients</a></li>
           <li><a href="#" class="text-light text-decoration-none">Contact us</a></li>
-          <li><a href="#" class="text-light text-decoration-none">FAQs</a></li>
+          <li><a href="pages/faq-section-full.php" class="text-light text-decoration-none">FAQs</a></li>
         </ul>
       </div>
 

--- a/pages/faq-section.php
+++ b/pages/faq-section.php
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="text-center mt-3">
-      <a href="faq-section.php" class="btn btn-outline-dark">Show More</a>
+      <a href="pages/faq-section-full.php" class="btn btn-outline-dark">Show More</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- link FAQ section 'Show More' button to the full FAQ page
- link footer FAQ to the full FAQ page

## Testing
- `php -l pages/faq-section.php` *(fails: php not installed)*
- `composer --version` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841c45f6e188325b1631a40474a36c0