### PR TITLE
Add service detail pages with links

### DIFF
--- a/brand-collaborations.php
+++ b/brand-collaborations.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Brand Collaborations</h1>
+  <p class="lead text-center">Details about our Brand Collaborations service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/creative-content.php
+++ b/creative-content.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Creative Content</h1>
+  <p class="lead text-center">Details about our Creative Content service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/includes/services-section.php
+++ b/includes/services-section.php
@@ -5,41 +5,53 @@
     <p class="text-muted mb-5">At Influentra Media, we empower brands with digital-first influencer strategies.</p>
     <div class="row g-4">
       <div class="col-6 col-sm-4 col-lg-2 ">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service1.png" class="img-fluid mb-3" alt="Pro Audio">
-          <h6 class="fw-bold mb-0">Pro Audio Influencers</h6>
-        </div>
+        <a href="pro-audio-influencers.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service1.png" class="img-fluid mb-3" alt="Pro Audio">
+            <h6 class="fw-bold mb-0">Pro Audio Influencers</h6>
+          </div>
+        </a>
       </div>
       <div class="col-6 col-sm-4 col-lg-2">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service2.png" class="img-fluid mb-3" alt="Campaigns">
-          <h6 class="fw-bold mb-0">Social Campaigns</h6>
-        </div>
+        <a href="social-campaigns.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service2.png" class="img-fluid mb-3" alt="Campaigns">
+            <h6 class="fw-bold mb-0">Social Campaigns</h6>
+          </div>
+        </a>
       </div>
       <div class="col-6 col-sm-4 col-lg-2">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service3.png" class="img-fluid mb-3" alt="Content">
-          <h6 class="fw-bold mb-0">Creative Content</h6>
-        </div>
+        <a href="creative-content.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service3.png" class="img-fluid mb-3" alt="Content">
+            <h6 class="fw-bold mb-0">Creative Content</h6>
+          </div>
+        </a>
       </div>
       <div class="col-6 col-sm-4 col-lg-2">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service4.png" class="img-fluid mb-3" alt="Collabs">
-          <h6 class="fw-bold mb-0">Brand Collabs</h6>
-        </div>
+        <a href="brand-collaborations.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service4.png" class="img-fluid mb-3" alt="Collabs">
+            <h6 class="fw-bold mb-0">Brand Collabs</h6>
+          </div>
+        </a>
       </div>
       <div class="col-6 col-sm-4 col-lg-2">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service5.png" class="img-fluid mb-3" alt="Reviews">
-          <h6 class="fw-bold mb-0">Review Generation</h6>
-        </div>
+        <a href="review-generation.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service5.png" class="img-fluid mb-3" alt="Reviews">
+            <h6 class="fw-bold mb-0">Review Generation</h6>
+          </div>
+        </a>
       </div>
-    
+
       <div class="col-6 col-sm-4 col-lg-2">
-        <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
-          <img src="img/service6.png" class="img-fluid mb-3" alt="Website Dev">
-          <h6 class="fw-bold mb-0">Website Development</h6>
-        </div>
+        <a href="website-development.php" class="text-decoration-none text-dark">
+          <div class="service-card p-4 shadow-sm bg-white rounded-4 h-100">
+            <img src="img/service6.png" class="img-fluid mb-3" alt="Website Dev">
+            <h6 class="fw-bold mb-0">Website Development</h6>
+          </div>
+        </a>
       </div>
     </div>
   </div>

--- a/pro-audio-influencers.php
+++ b/pro-audio-influencers.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Pro Audio Influencers</h1>
+  <p class="lead text-center">Details about our Pro Audio Influencers service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/review-generation.php
+++ b/review-generation.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Review Generation</h1>
+  <p class="lead text-center">Details about our Review Generation service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/services.php
+++ b/services.php
@@ -106,6 +106,7 @@
     <div class="row justify-content-center">
       <!-- Service: Pro Audio Influencers -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="pro-audio-influencers.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service1.png" alt="Pro Audio Influencers" class="service-icon mb-2">
           <div class="service-title">🎧 Pro Audio Influencers</div>
@@ -115,9 +116,11 @@
           </div>
           <div class="service-meta">🔍 Target: musicians, producers, audio brands<br>📈 Result: trust, demos, engagement</div>
         </div>
+        </a>
       </div>
       <!-- Service: Social Campaigns -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="social-campaigns.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service2.png" alt="Social Campaigns" class="service-icon mb-2">
           <div class="service-title">📣 Social Campaigns</div>
@@ -127,9 +130,11 @@
           </div>
           <div class="service-meta">💡 Platforms: Instagram, TikTok, YouTube<br>🎯 Goal: reach, engagement, visibility</div>
         </div>
+        </a>
       </div>
       <!-- Service: Creative Content -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="creative-content.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service3.png" alt="Creative Content" class="service-icon mb-2">
           <div class="service-title">✨ Creative Content</div>
@@ -139,9 +144,11 @@
           </div>
           <div class="service-meta">📷 Deliverables: videos, UGC, stories<br>🔥 Uses: ads, feed, campaigns</div>
         </div>
+        </a>
       </div>
       <!-- Service: Brand Collabs -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="brand-collaborations.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service4.png" alt="Brand Collabs" class="service-icon mb-2">
           <div class="service-title">🤝 Brand Collaborations</div>
@@ -151,9 +158,11 @@
           </div>
           <div class="service-meta">🧠 Focus: trust, repeat visibility, results<br>🚀 Ideal: launches, seasonal, ambassadors</div>
         </div>
+        </a>
       </div>
       <!-- Service: Review Generation -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="review-generation.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service5.png" alt="Review Generation" class="service-icon mb-2">
           <div class="service-title">🌟 Review Generation</div>
@@ -163,9 +172,11 @@
           </div>
           <div class="service-meta">⭐ Types: unboxing, testimonials<br>🛒 Goal: conversion-focused UGC</div>
         </div>
+        </a>
       </div>
       <!-- Service: Website Development -->
       <div class="col-md-6 col-lg-4 d-flex">
+        <a href="website-development.php" class="text-decoration-none text-dark w-100">
         <div class="service-card w-100">
           <img src="img/service6.png" alt="Website Development" class="service-icon mb-2">
           <div class="service-title">💻 Website Development</div>
@@ -175,6 +186,7 @@
           </div>
           <div class="service-meta">🛠️ Tech: HTML, CSS, PHP, Bootstrap<br>🌐 Add-ons: CMS, landing pages</div>
         </div>
+        </a>
       </div>
     </div>
   </div>

--- a/social-campaigns.php
+++ b/social-campaigns.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Social Campaigns</h1>
+  <p class="lead text-center">Details about our Social Campaigns service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/website-development.php
+++ b/website-development.php
@@ -1,0 +1,6 @@
+<?php include 'includes/header.php'; ?>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Website Development</h1>
+  <p class="lead text-center">Details about our Website Development service will be placed here.</p>
+</div>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add pages describing each service and load header/footer
- link service cards on the homepage and Services page to new pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ffd0e27883259ed018a630b2aa80