### PR TITLE
Add service page content and meta support

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -9,7 +9,10 @@ if (session_status() === PHP_SESSION_NONE) {
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Influentra</title>
+  <title><?= isset($page_title) ? htmlspecialchars($page_title) : 'Influentra' ?></title>
+  <?php if (isset($page_description)): ?>
+  <meta name="description" content="<?= htmlspecialchars($page_description) ?>">
+  <?php endif; ?>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="<?= $base_url ?>/css/style.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/pro-audio-influencers.php
+++ b/pro-audio-influencers.php
@@ -1,6 +1,13 @@
-<?php include 'includes/header.php'; ?>
+<?php
+$page_title = 'Pro Audio Influencers';
+$page_description = 'Connect your brand with respected creators in the audio community.';
+include 'includes/header.php';
+?>
 <div class="container py-5 simple-page">
   <h1 class="text-center">Pro Audio Influencers</h1>
-  <p class="lead text-center">Details about our Pro Audio Influencers service will be placed here.</p>
+  <img class="img-fluid mb-4" src="img/pro-audio-cover.jpg" alt="Pro Audio Influencers">
+  <p>Reach musicians, podcasters and audio engineers through authentic creator collaborations that showcase your products in action.</p>
+  <p><strong>What We Offer:</strong> end-to-end campaign strategy, product demonstrations, and in-depth reviews across the channels audio professionals trust.</p>
+  <p><strong>Why Choose Influentra:</strong> we specialize in the pro audio niche, matching your brand with influencers who drive real engagement and credibility.</p>
 </div>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- support page-level title and description in `header.php`
- add meta details and marketing copy to `pro-audio-influencers.php`

## Testing
- `php -l includes/header.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68430770a5b48325bb1ae171700bcf5b