### PR TITLE
Add service cover images

### DIFF
--- a/brand-collaborations.php
+++ b/brand-collaborations.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Brand Collaborations</h1>
   <p class="lead text-center">Details about our Brand Collaborations service will be placed here.</p>
 </div>

--- a/creative-content.php
+++ b/creative-content.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Creative Content</h1>
   <p class="lead text-center">Details about our Creative Content service will be placed here.</p>
 </div>

--- a/css/style.css
+++ b/css/style.css
@@ -314,4 +314,12 @@ html {
   margin-bottom: 1rem;
 }
 
+/* Optional cover image styling for service pages */
+.service-cover {
+  max-height: 400px;
+  width: 100%;
+  object-fit: cover;
+  margin-bottom: 1.5rem;
+}
+
 

--- a/pro-audio-influencers.php
+++ b/pro-audio-influencers.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Pro Audio Influencers</h1>
   <p class="lead text-center">Details about our Pro Audio Influencers service will be placed here.</p>
 </div>

--- a/review-generation.php
+++ b/review-generation.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Review Generation</h1>
   <p class="lead text-center">Details about our Review Generation service will be placed here.</p>
 </div>

--- a/social-campaigns.php
+++ b/social-campaigns.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Social Campaigns</h1>
   <p class="lead text-center">Details about our Social Campaigns service will be placed here.</p>
 </div>

--- a/website-development.php
+++ b/website-development.php
@@ -1,5 +1,6 @@
 <?php include 'includes/header.php'; ?>
 <div class="container py-5 simple-page">
+  <img src="img/service-placeholder.jpg" class="img-fluid mb-4 service-cover" alt="Service Cover">
   <h1 class="text-center">Website Development</h1>
   <p class="lead text-center">Details about our Website Development service will be placed here.</p>
 </div>


### PR DESCRIPTION
## Summary
- add a service placeholder image
- include service cover images at the top of service pages
- style the cover image with a new `.service-cover` rule

## Testing
- `composer validate --no-check-all` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684307aa6b848325a5cc26a4f97b4c0e